### PR TITLE
Add metadata directory configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,14 @@ This file contains environment-specific settings for different operating systems
 - **base_dir**: Base directory where the project is located.
 - **log_dir**: Directory for log files.
 - **image_dir**: Directory where images are stored (used for watermarks).
+- **metadata_dir**: Directory to store extracted metadata files (defaults to `./metadata/fb_tb`).
+- **test_url**: Sample URL used by the test suite for download verification.
 - **logging**: Log settings, including logging level, log file paths, and console output.
 
 ### Customizable Values
 
 - **Paths**: Many scripts rely on specific paths for input and output files. These can be adjusted in the `config.json` and `app_config.json` files.
-  - Example: `source_path`, `cookie_path`, `image_dir`.
+  - Example: `source_path`, `cookie_path`, `image_dir`, `metadata_dir`, `test_url`.
 - **Logging**: Customize log levels (DEBUG, INFO, etc.) and log file paths for debugging and monitoring.
 - **Watermark Settings**: Adjust watermark options such as `font`, `font_size`, and `position` in `watermark_config`.
 

--- a/conf/app_config.json
+++ b/conf/app_config.json
@@ -5,6 +5,8 @@
         "noplaylist": true,
         "cookie_path": "./app/data/cookies.txt"
     },
+    "metadata_dir": "./metadata/fb_tb",
+    "test_url": "https://www.facebook.com/share/v/19G7Jx2x2n/?mibextid=wwXIfr&__cft__[0]=AZWs3WaCFeC33JnjAcnjMQY3QtjFqvbJRzFTrsf8f5rSrAaIJD_vGKwFjnV9z_bDTGhR9vOJo1-e_7dveL6RpZHG2qRLXLxnDAEccB6cF5cOQWj1r6gVfZNbwKi0sffOUKc&__tn__=R]-R",
     "watermark_config": {
         "font": "Arial Bold",
         "font_size": 64,

--- a/lib/python_utils/downloader5.py
+++ b/lib/python_utils/downloader5.py
@@ -71,6 +71,26 @@ def extract_metadata(params):
     cookie_path = params.get("cookie_path")
     metadata_path = params.get("metadata_path")
 
+    # Determine metadata save path
+    if not metadata_path:
+        try:
+            current_dir = os.path.dirname(os.path.abspath(__file__))
+            base_dir = os.path.join(current_dir, "../../")
+            config_path = os.path.join(base_dir, "conf/app_config.json")
+            with open(config_path, "r") as f:
+                app_config = json.load(f)
+            metadata_dir = app_config.get("metadata_dir", "./metadata/fb_tb")
+        except Exception as e:
+            logger.warning(f"Could not read app_config.json: {e}")
+            metadata_dir = "./metadata/fb_tb"
+
+        if not os.path.exists(metadata_dir):
+            os.makedirs(metadata_dir, exist_ok=True)
+
+        filename = f"{int(time.time())}.json"
+        metadata_path = unique_output_path(metadata_dir, filename)
+        params["metadata_path"] = metadata_path
+
     try:
         # Set up yt-dlp options for extracting metadata
         ydl_opts = {

--- a/t/18.download.t
+++ b/t/18.download.t
@@ -8,6 +8,7 @@ use FindBin;
 use Cwd 'abs_path';
 use Log::Log4perl;
 use File::Path 'make_path';
+use JSON qw(decode_json);
 
 # Set log directory and file
 my $log_dir = File::Spec->catdir($FindBin::Bin, '..', 'logs');
@@ -48,7 +49,12 @@ my $frobnitz = Acme::Frobnitz->new();
 #my $test_url = 'https://www.youtube.com/watch?v=ai2KJDqgh7M'; # j m
 
 
-my $test_url = 'https://www.facebook.com/share/v/19G7Jx2x2n/?mibextid=wwXIfr&__cft__[0]=AZWs3WaCFeC33JnjAcnjMQY3QtjFqvbJRzFTrsf8f5rSrAaIJD_vGKwFjnV9z_bDTGhR9vOJo1-e_7dveL6RpZHG2qRLXLxnDAEccB6cF5cOQWj1r6gVfZNbwKi0sffOUKc&__tn__=R]-R'; # fb jun 17
+my $config_file = File::Spec->catfile($FindBin::Bin, '..', 'conf', 'app_config.json');
+open my $cfg_fh, '<', $config_file or die "Cannot open $config_file: $!";
+my $json_text = do { local $/; <$cfg_fh> };
+close $cfg_fh;
+my $config = decode_json($json_text);
+my $test_url = $config->{test_url} // die "test_url not found in $config_file";
 
 # BEGIN TESTS
 $logger->info("Starting test suite for Acme::Frobnitz");


### PR DESCRIPTION
## Summary
- create `metadata/` directory
- add `metadata_dir` config option
- improve `extract_metadata` so default path is from config
- document `metadata_dir` in README
- load test URL from `app_config.json` for `18.download.t`

## Testing
- `prove -lv t` *(fails: Can't locate IPC/System/Simple.pm)*

------
https://chatgpt.com/codex/tasks/task_e_685486dcdaa0832b9265493b17a81f35