### PR TITLE
Add metadata-driven download test

### DIFF
--- a/metadata/test1.json
+++ b/metadata/test1.json
@@ -1,6 +1,8 @@
 {
     "download_path": "/media/fritz/E4B0-3FC21/2025-05-13",
     "url": "https://www.facebook.com/share/v/19G7Jx2x2n/?mibextid=wwXIfr&__cft__[0]=AZWRlnH4PI4SsDap9XmHIiJ2UNb09CUq_fiXDnUeamxAKHTixL3j91_Rf4Q1qmRBQ2tqftspACfuRXaAJjLiaKAjHoywF6iNy5fZLyCy2VBBFxu7nrn3vmenyzjG8SezVAfyBhx7-AKXqXNqJ87LE4nM&__tn__=R]-R",
-   
-    
+    "tasks": {
+        "perform_download": null,
+        "apply_watermark": null
+    }
 }

--- a/t/20.metadata_download.t
+++ b/t/20.metadata_download.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use File::Spec;
+use FindBin;
+use JSON qw(decode_json encode_json);
+use Log::Log4perl;
+use File::Path 'make_path';
+
+# Logging setup similar to existing tests
+my $log_dir  = File::Spec->catdir($FindBin::Bin, '..', 'logs');
+my $log_file = File::Spec->catfile($log_dir, 'acme-frobnitz.log');
+
+unless (-d $log_dir) {
+    eval { make_path($log_dir) };
+    die "Failed to create log directory $log_dir: $@" if $@;
+}
+
+my $log_config = qq(
+log4perl.logger                    = INFO, FileAppender
+log4perl.appender.FileAppender     = Log::Log4perl::Appender::File
+log4perl.appender.FileAppender.filename = $log_file
+log4perl.appender.FileAppender.layout   = Log::Log4perl::Layout::PatternLayout
+log4perl.appender.FileAppender.layout.ConversionPattern = %d [%p] %m%n
+);
+
+Log::Log4perl->init(\$log_config);
+my $logger = Log::Log4perl->get_logger();
+
+use lib "$FindBin::Bin/../lib";
+use Acme::Frobnitz;
+
+my $metadata_file = File::Spec->catfile($FindBin::Bin, '..', 'metadata', 'test1.json');
+open my $fh, '<', $metadata_file or die "Cannot open $metadata_file: $!";
+my $json_text = do { local $/; <$fh> };
+close $fh;
+my $meta = decode_json($json_text);
+
+my $url = $meta->{url} or die "No URL in metadata";
+my $frobnitz = Acme::Frobnitz->new();
+
+can_ok('Acme::Frobnitz', 'download');
+
+my $download_out = eval { $frobnitz->download($url) };
+if ($@) {
+    fail('download threw exception');
+    BAIL_OUT($@);
+}
+else {
+    ok($download_out, 'download returned output');
+}
+my ($downloaded_file) = (split /\n/, $download_out)[-1];
+chomp($downloaded_file);
+$meta->{tasks}{perform_download} = $downloaded_file;
+
+ok($frobnitz->verify_file($downloaded_file), 'verify download');
+
+my $wm_out = eval { $frobnitz->add_watermark($downloaded_file) };
+if ($@) {
+    fail('watermark threw exception');
+    BAIL_OUT($@);
+}
+else {
+    ok($wm_out, 'watermark returned output');
+}
+my ($wm_file) = (split /\n/, $wm_out)[-1];
+chomp($wm_file);
+$meta->{tasks}{apply_watermark} = $wm_file;
+
+# store updated metadata
+open my $out, '>', $metadata_file or die "Cannot write $metadata_file: $!";
+print $out encode_json($meta);
+close $out;
+
+ok(-e $wm_file, 'watermarked file exists');
+
+done_testing();


### PR DESCRIPTION
## Summary
- fix `metadata/test1.json` to contain valid JSON
- add a new Perl test `t/20.metadata_download.t` that loads a metadata file, runs download & watermark steps, and updates the metadata

## Testing
- `prove -lv t/20.metadata_download.t` *(fails: Can't locate JSON.pm)*
- `prove -lv t/19.download.t` *(fails: Can't locate Log/Log4perl.pm)*

------
https://chatgpt.com/codex/tasks/task_e_68549bcecfa8832bb0b7f3a43551b5a9