### PR TITLE
Add clip test and restore download test

### DIFF
--- a/t/19.download.t
+++ b/t/19.download.t
@@ -45,30 +45,16 @@ use Acme::Frobnitz;
 # Instantiate Frobnitz object for watermarking
 my $frobnitz = Acme::Frobnitz->new();
 
-# Optional metadata JSON for URL
-my $metadata_arg = shift @ARGV;
+# Test URL for download functionality
+#my $test_url = 'https://www.youtube.com/watch?v=ai2KJDqgh7M'; # j m
 
-my $test_url;
-if ($metadata_arg) {
-    my $metadata_file = -f $metadata_arg
-      ? $metadata_arg
-      : File::Spec->catfile($FindBin::Bin, '..', 'metadata', $metadata_arg);
 
-    open my $mfh, '<', $metadata_file or die "Cannot open $metadata_file: $!";
-    my $meta_json = do { local $/; <$mfh> };
-    close $mfh;
-    my $meta = decode_json($meta_json);
-    $test_url = $meta->{url} or die "No URL in $metadata_file";
-} else {
-    my $config_file =
-      File::Spec->catfile($FindBin::Bin, '..', 'conf', 'app_config.json');
-    open my $cfg_fh, '<', $config_file or die "Cannot open $config_file: $!";
-    my $json_text = do { local $/; <$cfg_fh> };
-    close $cfg_fh;
-    my $config = decode_json($json_text);
-    $test_url = $config->{test_url}
-      // die "test_url not found in $config_file";
-}
+my $config_file = File::Spec->catfile($FindBin::Bin, '..', 'conf', 'app_config.json');
+open my $cfg_fh, '<', $config_file or die "Cannot open $config_file: $!";
+my $json_text = do { local $/; <$cfg_fh> };
+close $cfg_fh;
+my $config = decode_json($json_text);
+my $test_url = $config->{test_url} // die "test_url not found in $config_file";
 
 # BEGIN TESTS
 $logger->info("Starting test suite for Acme::Frobnitz");

--- a/t/20.make_clips.t
+++ b/t/20.make_clips.t
@@ -1,0 +1,30 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use IPC::Run3 'run3';
+use FindBin;
+use File::Spec;
+use lib "$FindBin::Bin/../lib";
+use Acme::Frobnitz;
+
+my $script19 = File::Spec->catfile($FindBin::Bin, '19.download.t');
+my ($stdout, $stderr);
+run3([$^X, $script19], undef, \$stdout, \$stderr);
+my $tap = ($stdout // '') . ($stderr // '');
+
+my ($watermarked_file) = $tap =~ /Watermark added: ([^\n]+)/;
+ok($watermarked_file, 'captured watermarked file path');
+
+if ($watermarked_file) {
+    my $frobnitz = Acme::Frobnitz->new();
+    my $clips_out = eval { $frobnitz->make_clips($watermarked_file) };
+    if ($@) {
+        fail('make_clips threw exception');
+        diag($@);
+    } else {
+        ok($clips_out, 'make_clips returned output');
+    }
+}
+
+done_testing;


### PR DESCRIPTION
## Summary
- restore previous `19.download.t` logic
- add `20.make_clips.t` that runs `19.download.t` and pipes its output to `make_clips`

## Testing
- `perl -c t/19.download.t` *(fails: Log::Log4perl not installed)*
- `perl -c t/20.make_clips.t` *(fails: IPC::Run3 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68550ce3b568832ba644a2d557db7cb1