### PR TITLE
Add link defaults template

### DIFF
--- a/conf/link_defaults.json
+++ b/conf/link_defaults.json
@@ -1,0 +1,19 @@
+{
+    "download_path": "",
+    "url": "",
+    "video_download": {
+        "format": "bestvideo[height<=?1080]+bestaudio/best",
+        "bitrate": "5000k",
+        "noplaylist": true,
+        "cookie_path": "./app/data/cookies.txt"
+    },
+    "clips": [],
+    "tasks": {
+        "perform_download": null,
+        "apply_watermark": null,
+        "make_clips": null,
+        "extract_audio": null,
+        "generate_captions": null,
+        "post_processed": false
+    }
+}


### PR DESCRIPTION
## Summary
- add `link_defaults.json` with base structure for new video links

## Testing
- `prove -lv t/*.t` *(fails: IPC::System::Simple missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855bb53e4e0832bb303af04f22dec84