### PR TITLE
Add link defaults test

### DIFF
--- a/conf/link_defaults.json
+++ b/conf/link_defaults.json
@@ -1,0 +1,19 @@
+{
+    "download_path": "",
+    "url": "",
+    "video_download": {
+        "format": "bestvideo[height<=?1080]+bestaudio/best",
+        "bitrate": "5000k",
+        "noplaylist": true,
+        "cookie_path": "./app/data/cookies.txt"
+    },
+    "clips": [],
+    "tasks": {
+        "perform_download": null,
+        "apply_watermark": null,
+        "make_clips": null,
+        "extract_audio": null,
+        "generate_captions": null,
+        "post_processed": false
+    }
+}

--- a/t/23.link_defaults_instagram.t
+++ b/t/23.link_defaults_instagram.t
@@ -1,0 +1,35 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use File::Spec;
+use JSON::PP qw(decode_json encode_json);
+use File::Temp qw(tempfile);
+
+my $defaults_path = File::Spec->catfile($FindBin::Bin, '..', 'conf', 'link_defaults.json');
+open my $fh, '<', $defaults_path or die "Cannot open $defaults_path: $!";
+my $json_text = do { local $/; <$fh> };
+close $fh;
+my $data = decode_json($json_text);
+
+my $insta_link = 'https://www.instagram.com/reel/EXAMPLE/';
+$data->{url} = $insta_link;
+
+ok($data->{url} eq $insta_link, 'url field updated with instagram link');
+
+ok(exists $data->{video_download}, 'video_download config present');
+
+ok(exists $data->{tasks}, 'tasks section present');
+ok(!defined $data->{tasks}{perform_download}, 'perform_download defaults to undef');
+ok(!$data->{tasks}{post_processed}, 'post_processed defaults to false');
+
+my ($tmpfh, $tmpfile) = tempfile('linkXXXX', SUFFIX => '.json', UNLINK => 1);
+print $tmpfh encode_json($data);
+close $tmpfh;
+
+ok(-e $tmpfile, 'temporary metadata file created');
+
+# Clean up is automatic due to UNLINK => 1
+
+done_testing();


### PR DESCRIPTION
## Summary
- test instagram link integration using `conf/link_defaults.json`

## Testing
- `prove -lv t/23.link_defaults_instagram.t`
- `prove -lv t/*.t` *(fails: IPC::System::Simple missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855bb53e4e0832bb303af04f22dec84