### PR TITLE
Add LinkDefaults loader module for tests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -30,3 +30,4 @@
 ./lib/python_utils/make_clips.py
 ./conf/config.json
 ./conf/app_config.json
+./lib/LinkDefaults.pm

--- a/lib/LinkDefaults.pm
+++ b/lib/LinkDefaults.pm
@@ -1,0 +1,18 @@
+package LinkDefaults;
+use strict;
+use warnings;
+use Exporter 'import';
+use JSON::PP qw(decode_json);
+
+our @EXPORT_OK = qw(load_defaults);
+
+sub load_defaults {
+    my ($path) = @_;
+    open my $fh, '<', $path or die "Cannot open $path: $!";
+    local $/;
+    my $json = <$fh>;
+    close $fh;
+    return decode_json($json);
+}
+
+1;

--- a/t/24.link_defaults_instagram.t
+++ b/t/24.link_defaults_instagram.t
@@ -4,16 +4,15 @@ use warnings;
 use Test::More;
 use FindBin;
 use File::Spec;
-use JSON::PP qw(decode_json encode_json);
+use JSON::PP qw(encode_json);
+use lib "$FindBin::Bin/../lib";
+use LinkDefaults qw(load_defaults);
 use File::Temp qw(tempfile);
 
 my $defaults_path = File::Spec->catfile($FindBin::Bin, '..', 'conf', 'link_defaults.json');
-open my $fh, '<', $defaults_path or die "Cannot open $defaults_path: $!";
-my $json_text = do { local $/; <$fh> };
-close $fh;
-my $data = decode_json($json_text);
+my $data = load_defaults($defaults_path);
 
-my $insta_link = 'https://www.instagram.com/p/EXAMPLE/';
+my $insta_link = $data->{url};
 $data->{url} = $insta_link;
 
 ok($data->{url} eq $insta_link, 'url field updated with instagram link');


### PR DESCRIPTION
## Summary
- provide `LinkDefaults` module for loading `conf/link_defaults.json`
- refactor `t/24.link_defaults_instagram.t` to use the new loader and read the URL from JSON
- list the new module in `MANIFEST`

## Testing
- `perl -Ilib t/24.link_defaults_instagram.t`
- `prove -l t` *(fails: Can't locate IPC::System::Simple.pm)*

------
https://chatgpt.com/codex/tasks/task_e_685664e3f358832ba2beb54f35babbca