### PR TITLE
Add timeline composite creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,35 @@ git push origin main
 
 ---
 
+## Creating a Timeline Composite Image
+
+The `bin/composite_timeline.py` script renders a timeline defined in a JSON
+file and overlays optional images for specific events. Use it to create a single
+PNG that combines your timeline data with custom graphics.
+
+1. **Prepare a mapping file** that links event labels to image paths. An example
+   mapping is provided in `timeline/image_mapping_example.json`:
+
+   ```json
+   {
+     "The Canoa Operation": "path/to/canoa.png",
+     "The Mar del Plata Operation": "path/to/mardel.png"
+   }
+   ```
+
+2. **Run the script** with the timeline JSON, the mapping file, and the desired
+   output filename:
+
+   ```bash
+   python bin/composite_timeline.py timeline/composed_timeline_final.json \
+       timeline/image_mapping_example.json output.png
+   ```
+
+The resulting `output.png` will contain the timeline bars with your images
+positioned above the relevant events.
+
+---
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/bin/composite_timeline.py
+++ b/bin/composite_timeline.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import sys
+import os
+import json
+import logging
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+lib_path = os.path.join(current_dir, "../lib/python_utils")
+sys.path.append(lib_path)
+
+from timeline_compositor import compose_timeline_with_images
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(
+            "Usage: python composite_timeline.py <timeline_json> <mapping_json> <output_image>"
+        )
+        sys.exit(1)
+
+    timeline_json = sys.argv[1]
+    mapping_json = sys.argv[2]
+    output_image = sys.argv[3]
+
+    logging.basicConfig(level=logging.INFO)
+    with open(mapping_json, "r", encoding="utf-8") as f:
+        mapping = json.load(f)
+
+    compose_timeline_with_images(timeline_json, mapping, output_image)
+    print(output_image)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/python_utils/timeline_compositor.py
+++ b/lib/python_utils/timeline_compositor.py
@@ -1,0 +1,92 @@
+import os
+import json
+import logging
+from typing import Dict, Optional
+from PIL import Image, ImageDraw
+
+logger = logging.getLogger(__name__)
+
+
+def _load_json(path: str) -> dict:
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Timeline JSON not found: {path}")
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _create_canvas(canvas_data: dict) -> Image.Image:
+    width = canvas_data.get("width", 800)
+    height = canvas_data.get("height", 600)
+    bg_color = canvas_data.get("outer_background", {}).get("color", "white")
+    logger.debug(f"Creating canvas {width}x{height} with color {bg_color}")
+    return Image.new("RGB", (width, height), bg_color)
+
+
+def _draw_timeline_box(img: Image.Image, box: dict) -> ImageDraw.ImageDraw:
+    draw = ImageDraw.Draw(img)
+    x = box.get("x", 0)
+    y = box.get("y", 0)
+    width = box.get("width", img.width)
+    height = box.get("height", 100)
+    color = box.get("color", "white")
+    draw.rectangle([x, y, x + width, y + height], fill=color)
+    return draw
+
+
+def compose_timeline_with_images(
+    timeline_json: str,
+    image_map: Optional[Dict[str, str]] = None,
+    output_path: str = "timeline_output.png",
+) -> str:
+    """Create a composite timeline image using the provided JSON and images.
+
+    Args:
+        timeline_json: Path to the timeline JSON definition.
+        image_map: Optional mapping of event labels to image file paths.
+        output_path: Where to save the final image.
+    Returns:
+        Path to the saved image.
+    """
+    data = _load_json(timeline_json)
+    canvas_data = data.get("canvas", {})
+    timeline_box = canvas_data.get("timeline_box", {})
+    img = _create_canvas(canvas_data)
+    draw = _draw_timeline_box(img, timeline_box)
+
+    event_tracks = timeline_box.get("event_tracks", [])
+    for track in event_tracks:
+        y_axis = int(timeline_box.get("y", 0) + track.get("y_axis", 0) * timeline_box.get("height", 0))
+        bar_height = track.get("bar_height", 20)
+        for bar in track.get("bars", []):
+            x_pos = int(timeline_box.get("x", 0) + bar.get("x", 0))
+            width = int(bar.get("width", 0))
+            color = bar.get("color", "#000000")
+            draw.rectangle([x_pos, y_axis, x_pos + width, y_axis + bar_height], fill=color)
+            label = bar.get("label")
+            if image_map and label in image_map:
+                path = image_map[label]
+                try:
+                    event_img = Image.open(path).convert("RGBA")
+                    event_img.thumbnail((bar_height * 3, bar_height * 3))
+                    img.paste(event_img, (x_pos, y_axis - event_img.height - 4), event_img)
+                except Exception as exc:
+                    logger.warning(f"Failed to load image '{path}': {exc}")
+
+    img.save(output_path)
+    logger.info(f"Timeline composite saved to {output_path}")
+    return output_path
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Create a composite timeline image")
+    parser.add_argument("timeline_json", help="Path to timeline JSON file")
+    parser.add_argument("mapping_json", help="JSON file mapping event labels to images")
+    parser.add_argument("output_image", help="Output image file")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    mapping = _load_json(args.mapping_json)
+    compose_timeline_with_images(args.timeline_json, mapping, args.output_image)
+    print(args.output_image)

--- a/timeline/image_mapping_example.json
+++ b/timeline/image_mapping_example.json
@@ -1,0 +1,4 @@
+{
+  "The Canoa Operation": "path/to/canoa.png",
+  "The Mar del Plata Operation": "path/to/mardel.png"
+}


### PR DESCRIPTION
## Summary
- create a Python utility `timeline_compositor.py` to render a timeline JSON and overlay event images
- add CLI wrapper `bin/composite_timeline.py`
- document composite timeline usage in README
- provide a sample mapping JSON for images

## Testing
- `python -m py_compile lib/python_utils/timeline_compositor.py bin/composite_timeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6858e43eab80832b90072ea9c6b334ec