### PR TITLE
Add Google Drive image downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ PNG that combines your timeline data with custom graphics.
 The resulting `output.png` will contain the timeline bars with your images
 positioned above the relevant events.
 
+### Downloading Image Assets
+
+Some image assets are provided via Google Drive links stored in
+`timeline/image_source_link.json`. Use the helper script
+`bin/download_images.py` to retrieve them:
+
+```bash
+python bin/download_images.py timeline/image_source_link.json downloaded_images
+```
+
+The script downloads each listed file into the specified directory so it can be
+used in your timeline composites.
+
 ---
 
 ## License

--- a/bin/download_images.py
+++ b/bin/download_images.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""Download images listed in a JSON file from Google Drive."""
+import json
+import os
+import sys
+from typing import List
+
+import requests
+
+GOOGLE_DRIVE_DOWNLOAD_URL = "https://drive.google.com/uc?export=download"
+
+
+def extract_drive_id(url: str) -> str:
+    """Extract the file ID from a Google Drive share link."""
+    if "/d/" in url:
+        return url.split("/d/")[1].split("/")[0]
+    raise ValueError(f"Cannot extract file id from URL: {url}")
+
+
+def get_confirm_token(response: requests.Response) -> str:
+    for key, value in response.cookies.items():
+        if key.startswith("download_warning"):
+            return value
+    return ""
+
+
+def save_response_content(response: requests.Response, destination: str) -> None:
+    chunk_size = 32768
+    with open(destination, "wb") as f:
+        for chunk in response.iter_content(chunk_size):
+            if chunk:
+                f.write(chunk)
+
+
+def download_file(file_id: str, dest_path: str) -> None:
+    session = requests.Session()
+    response = session.get(
+        GOOGLE_DRIVE_DOWNLOAD_URL, params={"id": file_id}, stream=True
+    )
+    token = get_confirm_token(response)
+    if token:
+        params = {"id": file_id, "confirm": token}
+        response = session.get(GOOGLE_DRIVE_DOWNLOAD_URL, params=params, stream=True)
+    save_response_content(response, dest_path)
+
+
+def download_from_json(json_path: str, output_dir: str) -> List[str]:
+    with open(json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    urls = data.get("gdrive_urls", [])
+    if not urls:
+        raise ValueError("No 'gdrive_urls' found in JSON file")
+
+    os.makedirs(output_dir, exist_ok=True)
+    downloaded = []
+
+    for url in urls:
+        file_id = extract_drive_id(url)
+        dest_file = os.path.join(output_dir, file_id)
+        download_file(file_id, dest_file)
+        downloaded.append(dest_file)
+        print(f"Downloaded {dest_file}")
+
+    return downloaded
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python download_images.py <link_json> [output_dir]")
+        sys.exit(1)
+
+    link_json = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else "downloaded_images"
+    download_from_json(link_json, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/timeline/image_source_link.json
+++ b/timeline/image_source_link.json
@@ -1,0 +1,5 @@
+{
+    "gdrive_urls": [
+        "https://drive.google.com/file/d/183ApztBuVowAg4ITbLypUo7XcXBD64sw/view?usp=share_link"
+    ]
+}


### PR DESCRIPTION
## Summary
- add `image_source_link.json` for storing Google Drive links
- add `download_images.py` script to fetch files from Google Drive
- document how to use the new script in README

## Testing
- `black bin/download_images.py`
- `black timeline/image_source_link.json`
- `prove -lv t` *(fails: Can't locate IPC/System/Simple.pm)*

------
https://chatgpt.com/codex/tasks/task_e_6859880d8588832b8762652a5d4ab146