### PR TITLE
Add tar unpacking task

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ python bin/download_images.py timeline/image_source_link.json downloaded_images
 The script downloads each listed file into the specified directory so it can be
 used in your timeline composites.
 
+### Extracting Tar Archives
+
+Use `conf/untar_config.json` to download a tar archive from Google Drive and
+extract a sorted list of its contents. Run the dispatcher with this config:
+
+```bash
+python bin/dispatch.py conf/untar_config.json
+```
+
 ---
 
 ## License

--- a/bin/call_untar_and_sort.py
+++ b/bin/call_untar_and_sort.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""Download a tar archive and extract a sorted file list using a config file."""
+import json
+import os
+import sys
+import subprocess
+import tempfile
+
+import requests
+
+
+def download_file(url: str, dest: str) -> str:
+    """Download file from URL to destination path."""
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    with open(dest, "wb") as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                f.write(chunk)
+    return dest
+
+
+def run_untar_and_list(tar_path: str, output_dir: str) -> str:
+    """Run the provided untar_and_list script and return the JSON file path."""
+    script = os.path.join(os.path.dirname(__file__), "untar_and_list.py")
+    result = subprocess.run(
+        [sys.executable, script, tar_path, output_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    json_path = result.stdout.strip().splitlines()[-1]
+    return json_path
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python call_untar_and_sort.py <config_json>")
+        sys.exit(1)
+
+    config_path = sys.argv[1]
+    with open(config_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    url = data.get("url")
+    download_path = data.get("download_path", "downloads")
+    os.makedirs(download_path, exist_ok=True)
+
+    tmp_fd, tmp_tar = tempfile.mkstemp(suffix=".tar")
+    os.close(tmp_fd)
+    download_file(url, tmp_tar)
+
+    output_dir = os.path.join(download_path, "untarred")
+    os.makedirs(output_dir, exist_ok=True)
+
+    json_list = run_untar_and_list(tmp_tar, output_dir)
+    print(json_list)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/dispatch.py
+++ b/bin/dispatch.py
@@ -9,6 +9,7 @@ TASK_SCRIPTS = {
     "perform_download": "bin/call_download.py",
     "apply_watermark": "bin/call_watermark.py",
     "make_clips": "bin/call_clips.py",
+    "untar_and_sort": "bin/call_untar_and_sort.py",
 }
 
 
@@ -30,7 +31,7 @@ def main(path):
     tasks = data.get("tasks", {})
     last = tasks.get("perform_download") if isinstance(tasks.get("perform_download"), str) else None
 
-    for task in ["perform_download", "apply_watermark", "make_clips"]:
+    for task in ["perform_download", "apply_watermark", "make_clips", "untar_and_sort"]:
         state = tasks.get(task)
         if state is True:
             if task != "perform_download" and not last:
@@ -38,7 +39,12 @@ def main(path):
                 continue
             script = os.path.join(os.path.dirname(__file__), os.pardir, TASK_SCRIPTS[task])
             script = os.path.normpath(script)
-            arg = url if task == "perform_download" else last
+            if task == "perform_download":
+                arg = url
+            elif task == "untar_and_sort":
+                arg = path
+            else:
+                arg = last
             result_path = run_script(script, arg)
             tasks[task] = result_path
             last = result_path or last

--- a/conf/untar_config.json
+++ b/conf/untar_config.json
@@ -1,0 +1,8 @@
+{
+    "download_path": "/home/fritz/Desktop/downloads",
+    "url": "https://drive.google.com/uc?id=183ApztBuVowAg4ITbLypUo7XcXBD64sw",
+    "clips": [],
+    "tasks": {
+        "untar_and_sort": true
+    }
+}


### PR DESCRIPTION
## Summary
- add config example for tar extraction
- support a new `untar_and_sort` task in dispatcher
- script to download and extract a tar archive
- document how to run the new task

## Testing
- `prove -lv t/00-load.t` *(fails: Can't locate IPC::System::Simple.pm)*
- `python bin/call_untar_and_sort.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6859ab306dec832bb26e251a1e3ae75d