### PR TITLE
Add default task config

### DIFF
--- a/conf/default_tasks.json
+++ b/conf/default_tasks.json
@@ -1,0 +1,11 @@
+{
+  "default_tasks": {
+    "perform_download": true,
+    "apply_watermark": true,
+    "make_clips": false,
+    "extract_audio": false,
+    "generate_captions": false,
+    "post_processed": false
+  }
+}
+


### PR DESCRIPTION
## Summary
- include a `conf/default_tasks.json` with standard task defaults
- set `make_clips` default to `false`

## Testing
- `prove -l t` *(fails: IPC::System::Simple module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859fed4f3e0832bb59925d7463f6218