### PR TITLE
Fix script path for clipped captions

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,7 +4,6 @@
 ./bin/call_ken.py
 ./bin/call_clips.py
 ./bin/call_captions.py
-./bin/call_clipped_captions.py
 ./bin/call_screenshot.py
 ./bin/4.driver.pl
 ./Changes

--- a/lib/Acme/Frobnitz.pm
+++ b/lib/Acme/Frobnitz.pm
@@ -159,7 +159,8 @@ sub add_clipped_captions {
     die "Input video file not provided.\n" unless $input_video;
 
 
-    my $script_path = $class->_get_script_path("call_clipped_captions.py");
+    # use the current captioning script
+    my $script_path = $class->_get_script_path("call_captions.py");
     my $python_path = $class->_get_python_path();
     print "Running command: $python_path $script_path $input_video \n";
     $DB::single = 1; 


### PR DESCRIPTION
## Summary
- use `call_captions.py` for the clipped captioning step
- clean MANIFEST entry for removed script

## Testing
- `prove -l t` *(fails: IPC::System::Simple missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859fed8bf20832ba170048a872486ad